### PR TITLE
Fixed indentation of comments for buildout config.

### DIFF
--- a/Preferences/Miscellaneous.tmPreferences
+++ b/Preferences/Miscellaneous.tmPreferences
@@ -31,6 +31,12 @@
                 <key>value</key>
                 <string># </string>
             </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_DISABLE_INDENT</string>
+                <key>value</key>
+                <string>yes</string>
+            </dict>
         </array>
         <key>smartTypingPairs</key>
         <array>


### PR DESCRIPTION
Comments in buildout config files must be in the beginning of the line to get recognised.

when using "toggle comments" instead of typing "#" it didn't work for intended lines like:

```
parts = 
    section1
    section2
```

which leaded to:

```
parts = 
    section1
   # section2
```

instead of

```
parts = 
    section1
#   section2
```

i solved that by adding the "TM_COMMENT_DISABLE_INDENT" to the Miscellaneous.tmPreferences file.
