### PR TITLE
Added -= to operator definition to make var highlighting work again.

### DIFF
--- a/Syntaxes/Buildout Config.tmLanguage
+++ b/Syntaxes/Buildout Config.tmLanguage
@@ -51,6 +51,18 @@
             <string>^([a-zA-Z0-9_.-]+)\b\s*(=|\+=|\-=)</string>
         </dict>
         <dict>
+            <key>captures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>constant.language.reference.buildout</string>
+                </dict>
+            </dict>
+            <key>match</key>
+            <string><![CDATA[^<=\s*([a-zA-Z0-9_.-]+)]]></string>
+        </dict>
+        <dict>
             <key>match</key>
             <string>^recipe\s*=\s*(.*)$</string>
             <key>name</key>

--- a/Syntaxes/Buildout Config.tmLanguage
+++ b/Syntaxes/Buildout Config.tmLanguage
@@ -48,7 +48,7 @@
                 </dict>
             </dict>
             <key>match</key>
-            <string>^([a-zA-Z0-9_.-]+)\b\s*(=|\+=)</string>
+            <string>^([a-zA-Z0-9_.-]+)\b\s*(=|\+=|\-=)</string>
         </dict>
         <dict>
             <key>match</key>


### PR DESCRIPTION
sry to bother you again ;)

i found the place to make the highlighting work for `var_name -= value`

and i added a definition for `<= section_name_to_include` to highlight like `${section_name:var_name}`.
